### PR TITLE
cargo: Omit bloat from packaged crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,15 @@ version = "0.1.0"
 edition = "2021"
 build = "build.rs"
 license = "MIT/Apache-2.0"
+license-file = "LICENSE"
 description = "Image downsampler crate using ISPC"
+documentation = "https://docs.rs/ispc-downsampler"
+include = [
+    "/src/",
+    "/benches/",
+    "/examples/",
+    "/README.md",
+]
 
 [dependencies]
 ispc_rt = "1.0.7"


### PR DESCRIPTION
All kinds of unnecessary files such as testing assets, gitignore and other untracked files are included in the packaged crate [1], unnecessary bloating it.

Note that some files are included by default, see:

    cargo package -l

For an accurate overview.

[1]: https://docs.rs/crate/ispc-downsampler/0.1.0/source/
