### PR TITLE
build: Don't set ISPC target OS to the machine that currently runs the build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -5,18 +5,6 @@ fn compile_bindings() {
     // Compile our ISPC library, this call will exit with EXIT_FAILURE if
     // compilation fails.
 
-    let target_os = if cfg!(target_os = "windows") {
-        TargetOS::Windows
-    } else if cfg!(target_os = "linux") {
-        TargetOS::Linux
-    } else if cfg!(target_os = "macos") {
-        TargetOS::Macos
-    } else if cfg!(target_os = "android") {
-        TargetOS::Android
-    } else {
-        panic!("Unsupported platform")
-    };
-
     ispc_compile::Config::new()
         .file("src/ispc/kernels/lanczos3.ispc")
         .opt_level(2)
@@ -29,7 +17,6 @@ fn compile_bindings() {
             TargetISA::AVX512KNLi32x16,
             TargetISA::AVX512SKXi32x16,
         ])
-        .target_os(target_os)
         .math_lib(MathLib::Fast)
         .out_dir("src/ispc")
         .compile("downsample_ispc");


### PR DESCRIPTION
The `CARGO_CFG_TARGET_OS` environment variable should be used for this, as `cfg!()` represents the target the `build.rs` script was compiled for and will contain the wrong value when cross-compiling for a different target.

Empirical evidence suggests that it's not necessary to explicitly set `target_os` anyway since it is already conveyed in the `TARGET` triple environment variable.  It's not passed directly to ispc but at least `ispc-rs` uses it to identify the architecture, and it should should be irrelevant when not linking against external libraries.
