### PR TITLE
lanczos3: Actually sample 7x7 instead of 6x6

### DIFF
--- a/src/ispc/kernels/lanczos3.ispc
+++ b/src/ispc/kernels/lanczos3.ispc
@@ -62,9 +62,8 @@ static inline uint8<4> resample_internal(uniform Image src_image, float<2> uv, u
     float<4> col = { 0, 0, 0, 0 };
     float weight = 0.0;
 
-    for(uniform int x = -3; x < 3; x++){
-        for(uniform int y = -3; y < 3; y++){
-
+    for (uniform int x = -3; x <= 3; x++) {
+        for (uniform int y = -3; y <= 3; y++) {
             float wx = lanczos3_filter((uniform float)x - offset.x);
             float wy = lanczos3_filter((uniform float)y - offset.y);
             float w = wx * wy;


### PR DESCRIPTION
`<` should have been `<=`, otherwise we only sample `[-3, -2, -1, 0, 1, 2]` biasing us towards the top-left of the pixels.
