### PR TITLE
Preserve alpha coverage on downsample

### DIFF
--- a/benches/basic.rs
+++ b/benches/basic.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use ispc_downsampler::{downsample, Format, Image};
+use ispc_downsampler::{downsample, AlphaCoverageSetting, Format, Image};
 use resize::{px::RGB, Type::Lanczos3};
 use stb_image::image::{load, LoadResult};
 use std::path::Path;
@@ -18,7 +18,14 @@ pub fn ispc_downsampler(c: &mut Criterion) {
         let target_height = (img.height / 4) as u32;
 
         c.bench_function("Downsample `square_test.png` using ispc_downsampler", |b| {
-            b.iter(|| downsample(&src_img, target_width, target_height))
+            b.iter(|| {
+                downsample(
+                    &src_img,
+                    target_width,
+                    target_height,
+                    AlphaCoverageSetting::None,
+                )
+            })
         });
     }
 }

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -1,5 +1,5 @@
 use image::{RgbImage, RgbaImage};
-use ispc_downsampler::{downsample, Format, Image};
+use ispc_downsampler::{downsample, AlphaCoverageSetting, Format, Image};
 use stb_image::image::{load, LoadResult};
 use std::path::Path;
 use std::time::Instant;
@@ -26,7 +26,17 @@ fn main() {
 
             let now = Instant::now();
             println!("Downsampling started!");
-            let downsampled_pixels = downsample(&src_img, target_width, target_height);
+            let downsampled_pixels = downsample(
+                &src_img,
+                target_width,
+                target_height,
+                match src_fmt {
+                    Format::RGB8 => AlphaCoverageSetting::None,
+                    Format::RGBA8 => AlphaCoverageSetting::RetainAlphaCoverage {
+                        alpha_cutoff: Some(0.5),
+                    },
+                },
+            );
             println!("Finished downsampling in {:.2?}!", now.elapsed());
 
             std::fs::create_dir_all("example_outputs").unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,10 +35,11 @@ impl<'a> Image<'a> {
     }
 
     fn get_alpha(&self, x: usize, y: usize) -> f32 {
-        self.pixels[x * 4 + 3 + y * 4 * self.width as usize] as f32 / 255.0
+        let pixel_index = x + y * self.width as usize;
+        self.pixels[pixel_index * 4 + 3] as f32 / 255.0
     }
 
-    pub fn calculate_alpha_coverage(&self, alpha_cutoff: Option<f32>) -> f32 {
+    fn calculate_alpha_coverage(&self, alpha_cutoff: Option<f32>) -> f32 {
         self.calculate_scaled_alpha_coverage(alpha_cutoff, 1.0f32)
     }
 
@@ -88,7 +89,7 @@ impl<'a> Image<'a> {
     /// Computes the scaling factor needed for the texture's alpha such that the desired
     /// coverage is best approximated
     /// Ported version of implementation in https://github.com/castano/nvidia-texture-tools/.
-    pub fn find_alpha_scale_for_coverage(
+    fn find_alpha_scale_for_coverage(
         &self,
         desired_coverage: f32,
         alpha_cutoff: Option<f32>,
@@ -133,7 +134,7 @@ impl<'a> Image<'a> {
     }
 }
 
-pub fn apply_alpha_scale(data: &mut [u8], alpha_scale: f32) {
+fn apply_alpha_scale(data: &mut [u8], alpha_scale: f32) {
     for pixel in data.iter_mut().skip(3).step_by(4) {
         *pixel = (*pixel as f32 * alpha_scale).min(255.0) as u8
     }
@@ -148,7 +149,7 @@ pub enum AlphaCoverageSetting {
 ///
 /// Will panic if the target width or height are higher than that of the source image.
 pub fn downsample(
-    src: &Image,
+    src: &Image<'_>,
     target_width: u32,
     target_height: u32,
     target_desired_alpha_coverage: AlphaCoverageSetting,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,16 +93,19 @@ impl<'a> Image<'a> {
         desired_coverage: f32,
         alpha_cutoff: Option<f32>,
     ) -> f32 {
+        // This range of potential scale values is an estimate. Especially the upper bound
+        // may not be sufficient for some use-cases, depending on the downscale
+        // compared to mip 0
+        // TO-DO: Figure out if this should be exposed
         let mut alpha_scale_range_start = 0.0;
+        let mut alpha_scale_range_end = 8.0;
 
-        let mut alpha_scale_range_end = 4.0;
-        // Possibly better to set this to 1.0 in the general case, but discrepency will be solved in
-        // one search step while having a better result for textures that need very high alpha scaling
         let mut alpha_scale = 1.0;
 
-        // Due to the subsampling when determining the alpha coverage of an image, we can technically
-        // overshoot the used alpha scale, so we should track of what was the
-        // best result so far and use that instead of the last found scale
+        // The search is done heuristically, so a tested alpha scale value
+        // does not directly map to the resulting alpha coverage. To ensure,
+        // we do not overwrite the best result, store
+        // the best result so far and use that instead of the last found scale
         let mut best_abs_diff = f32::INFINITY;
         let mut best_alpha_scale = alpha_scale;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,13 +38,13 @@ impl<'a> Image<'a> {
         self.pixels[x * 4 + 3 + y * 4 * self.width as usize] as f32 / 255.0
     }
 
-    /// Computes the percentage of texels that are visible in an alpha masked texture using
-    /// 4x4 subsampling.
-    /// Ported version of implementation in https://github.com/castano/nvidia-texture-tools/.
     pub fn calculate_alpha_coverage(&self, alpha_cutoff: Option<f32>) -> f32 {
         self.calculate_scaled_alpha_coverage(alpha_cutoff, 1.0f32)
     }
 
+    /// Computes the percentage of texels that are visible in an alpha masked texture using
+    /// 4x4 subsampling.
+    /// Ported version of implementation in https://github.com/castano/nvidia-texture-tools/.
     fn calculate_scaled_alpha_coverage(&self, alpha_cutoff: Option<f32>, scale: f32) -> f32 {
         // Edge-case for if the texture is downsampled to 1x1
         if self.width == 1 && self.height == 1 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,9 +95,8 @@ impl<'a> Image<'a> {
     ) -> f32 {
         let mut alpha_scale_range_start = 0.0;
 
-        // This value might need exposure for tweaking
-        let mut alpha_scale_range_end = 8.0;
-        let mut alpha_scale = 4.0;
+        let mut alpha_scale_range_end = 4.0;
+        let mut alpha_scale = 2.0;
 
         // Due to the subsampling when determining the alpha coverage of an image, we can technically
         // overshoot the used alpha scale. It's therefore necessary to keep track of what was the
@@ -127,11 +126,11 @@ impl<'a> Image<'a> {
         }
         best_alpha_scale
     }
-}
+}1
 
 pub fn apply_alpha_scale(data: &mut [u8], alpha_scale: f32) {
     for pixel in data.iter_mut().skip(3).step_by(4) {
-        *pixel = (*pixel as f32 * alpha_scale * 255.0).min(255.0).round() as u8
+        *pixel = (*pixel as f32 * alpha_scale).min(255.0).round() as u8
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,10 +95,10 @@ impl<'a> Image<'a> {
     ) -> f32 {
         let mut alpha_scale_range_start = 0.0;
 
-        let mut alpha_scale_range_end = 8.0;
+        let mut alpha_scale_range_end = 4.0;
         // Possibly better to set this to 1.0 in the general case, but discrepency will be solved in
         // one search step while having a better result for textures that need very high alpha scaling
-        let mut alpha_scale = 4.0;
+        let mut alpha_scale = 1.0;
 
         // Due to the subsampling when determining the alpha coverage of an image, we can technically
         // overshoot the used alpha scale, so we should track of what was the
@@ -108,7 +108,7 @@ impl<'a> Image<'a> {
 
         // 10-step binary search for the alpha multiplier that best matches
         // the desired alpha coverage
-        for _ in 0..12 {
+        for _ in 0..10 {
             let current_coverage = self.calculate_scaled_alpha_coverage(alpha_cutoff, alpha_scale);
             let coverage_diff = current_coverage - desired_coverage;
 
@@ -132,7 +132,7 @@ impl<'a> Image<'a> {
 
 pub fn apply_alpha_scale(data: &mut [u8], alpha_scale: f32) {
     for pixel in data.iter_mut().skip(3).step_by(4) {
-        *pixel = (*pixel as f32 * alpha_scale).min(255.0).round() as u8
+        *pixel = (*pixel as f32 * alpha_scale).min(255.0) as u8
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@ impl<'a> Image<'a> {
         }
         best_alpha_scale
     }
-}1
+}
 
 pub fn apply_alpha_scale(data: &mut [u8], alpha_scale: f32) {
     for pixel in data.iter_mut().skip(3).step_by(4) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,8 +140,16 @@ fn apply_alpha_scale(data: &mut [u8], alpha_scale: f32) {
     }
 }
 
+#[derive(Default)]
 pub enum AlphaCoverageSetting {
+    #[default]
     None,
+
+    /// Scales the alpha to the downscaled texture to preserve the overall alpha coverage.
+    /// If alpha cutoff is specified, any alpha value above it is considered visible
+    /// of which the percentage of visible texels will be.
+    /// Otherwise, visibility is considered a linear sum of the alpha values instead
+    /// and the source and target alpha coverage are calculated the same way
     RetainAlphaCoverage { alpha_cutoff: Option<f32> },
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ impl Format {
     }
 }
 
-/// Describes a source image which can be used for with `downsample`
+/// Describes a source image which can be used for `downsample`
 /// The pixel data is stored as a slice to avoid unnecessarily cloning it.
 pub struct Image<'a> {
     pixels: &'a [u8],
@@ -33,12 +33,110 @@ impl<'a> Image<'a> {
             format,
         }
     }
+
+    fn get_alpha(&self, x: usize, y: usize) -> f32 {
+        self.pixels[x * 4 + 3 + y * 4 * self.width as usize] as f32 / 255.0
+    }
+
+    /// Computes the percentage of texels that are visible in an alpha masked texture using
+    /// 4x4 subsampling.
+    /// Ported version of implementation in https://github.com/castano/nvidia-texture-tools/.
+    pub fn calculate_alpha_coverage(&self, alpha_cutoff: f32) -> f32 {
+        self.calculate_scaled_alpha_coverage(alpha_cutoff, 1.0f32)
+    }
+
+    fn calculate_scaled_alpha_coverage(&self, alpha_cutoff: f32, scale: f32) -> f32 {
+        let mut coverage = 0.0f32;
+        let subsample_factor = 4;
+
+        for y in 0..(self.height as usize) - 1 {
+            for x in 0..(self.width as usize) - 1 {
+                let top_left = (self.get_alpha(x, y) * scale).min(255.0);
+                let top_right = (self.get_alpha(x + 1, y) * scale).min(255.0);
+                let bottom_left = (self.get_alpha(x, y + 1) * scale).min(255.0);
+                let bottom_right = (self.get_alpha(x + 1, y + 1) * scale).min(255.0);
+
+                let mut texel_coverage = 0.0;
+                for sy in 0..subsample_factor {
+                    let fy = (sy as f32 + 0.5) / subsample_factor as f32;
+                    for sx in 0..subsample_factor {
+                        let fx = (sx as f32 + 0.5) / subsample_factor as f32;
+                        let alpha = top_left * (1.0 - fx) * (1.0 - fy)
+                            + top_right * fx * (1.0 - fy)
+                            + bottom_left * (1.0 - fx) * fy
+                            + bottom_right * fx * fy;
+                        if alpha > alpha_cutoff {
+                            texel_coverage += 1.0;
+                        }
+                    }
+                }
+                coverage += texel_coverage / (subsample_factor * subsample_factor) as f32;
+            }
+        }
+
+        coverage / ((self.width - 1) * (self.height - 1)) as f32
+    }
+
+    pub fn find_alpha_scale_for_coverage(&self, desired_coverage: f32, alpha_cutoff: f32) -> f32 {
+        let mut alpha_scale_range_start = 0.0;
+
+        // This value might need exposure for tweaking
+        let mut alpha_scale_range_end = 4.0;
+        let mut alpha_scale = 1.0;
+
+        // Due to the subsampling when determining the alpha coverage of an image, we can technically
+        // overshoot the used alpha scale. It's therefore necessary to keep track of what was the
+        // best result so far and use that instead of the last found scale
+        let mut best_abs_diff = f32::INFINITY;
+        let mut best_alpha_scale = alpha_scale;
+
+        // 10-step binary search for the alpha multiplier that best matches
+        // the desired alpha coverage
+        for _ in 0..10 {
+            let current_coverage = self.calculate_scaled_alpha_coverage(alpha_cutoff, alpha_scale);
+            let coverage_diff = current_coverage - desired_coverage;
+
+            if coverage_diff.abs() < best_abs_diff {
+                best_abs_diff = coverage_diff.abs();
+                best_alpha_scale = alpha_scale;
+            }
+
+            if coverage_diff < 0.0 {
+                alpha_scale_range_start = alpha_scale;
+            } else if coverage_diff > 0.0 {
+                alpha_scale_range_end = alpha_scale;
+            } else {
+                break;
+            }
+            alpha_scale = (alpha_scale_range_start + alpha_scale_range_end) / 2.0
+        }
+        best_alpha_scale
+    }
+}
+
+pub fn apply_alpha_scale(data: &mut [u8], alpha_scale: f32) {
+    for pixel in data.iter_mut() {
+        *pixel = (*pixel as f32 / alpha_scale).round() as u8
+    }
+}
+
+pub enum AlphaCoverageSetting {
+    None,
+    RetainAlphaCoverage {
+        target_alpha_coverage: f32,
+        alpha_cutoff: f32
+    }
 }
 
 /// Runs the ISPC kernel on the source image, sampling it down to the `target_width` and `target_height`. Returns the downsampled pixel data as a `Vec<u8>`.
 ///
 /// Will panic if the target width or height are higher than that of the source image.
-pub fn downsample(src: &Image, target_width: u32, target_height: u32) -> Vec<u8> {
+pub fn downsample(
+    src: &Image,
+    target_width: u32,
+    target_height: u32,
+    target_desired_alpha_coverage: AlphaCoverageSetting
+) -> Vec<u8> {
     assert!(src.width >= target_width, "The width of the source image is less than the target's width. You are trying to upsample rather than downsample");
     assert!(src.height >= target_height, "The width of the source image is less than the target's width. You are trying to upsample rather than downsample");
 
@@ -59,6 +157,11 @@ pub fn downsample(src: &Image, target_width: u32, target_height: u32) -> Vec<u8>
             src.pixels.as_ptr(),
             output.as_mut_ptr(),
         )
+    }
+
+    if let AlphaCoverageSetting::RetainAlphaCoverage { target_alpha_coverage, alpha_cutoff } = target_desired_alpha_coverage {
+        let scale = Image::new(&output, target_width, target_height, src.format).find_alpha_scale_for_coverage(target_alpha_coverage, alpha_cutoff);
+        apply_alpha_scale(&mut output, scale);
     }
 
     output


### PR DESCRIPTION
This makes it so that downsampling of images does not fully diminish the alpha channel (for alpha cutoff textures). This is essentially a port of the implementation in [nvdia texture tools](https://github.com/castano/nvidia-texture-tools/blob/aeddd65f81d36d8cb7b169b469ef25156666077e/src/nvimage/FloatImage.cpp#L1424). 

Ideally we do this in ISPC which will come in a later PR, but this is a good start.