### PR TITLE
Fix generate binaries action after upload-artifacts bump

### DIFF
--- a/.github/workflows/generate-binaries.yaml
+++ b/.github/workflows/generate-binaries.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: ISPC kernels
+          name: ISPC kernels Ubuntu
           path: |
             src/ispc/downsample_ispc.rs
             src/ispc/lib*.a
@@ -72,7 +72,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: ISPC kernels
+          name: ISPC kernels macOS
           path: |
             src/ispc/lib*.a
 
@@ -104,6 +104,6 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: ISPC kernels
+          name: ISPC kernels Windows
           path: |
             src/ispc/*.lib


### PR DESCRIPTION
Dependabot bumped upload-artifacts from v3 to v4 which has a breaking change that artifacts with the same name can no longer be uploaded. As a result, the generate binaries action would need to be run 3 times to generate all the binaries, which is annoying.

The only fix outlined for this change is to upload different named artifacts. An alternative thing we can do is to do download the artifacts at the end and zip them together.