### PR TITLE
Fix alpha coverage for images of single width/height

### DIFF
--- a/src/ispc/kernels/rescale_alpha.ispc
+++ b/src/ispc/kernels/rescale_alpha.ispc
@@ -13,45 +13,62 @@ float get_alpha(uniform Image image, uint64 x, uint64 y) {
 }
 
 uniform float calculate_scaled_alpha_coverage(uniform Image image, const uniform float* uniform alpha_cutoff, uniform float scale) {
-    // Edge-case for if the texture is downsampled to 1x1
-    if (image.size.x == 1 && image.size.y == 1) {
-        return 0.0f;
-    }
-    float coverage = 0.0f;
-    const uniform int subsample_factor = 4;
+    // Don't perform subsampling if the image dimensions don't allow for it
+    if (image.size.x == 1 || image.size.y == 1) {
+        float coverage = 0.0f;
+        for (uint64 x = 0; x < image.size.x; x++) {
+            for (uint64 y = 0; y < image.size.y; y++) {
+                float alpha = min((get_alpha(image, x, y) * scale), 1.0);
 
-    for (uint64 x = 0; x < image.size.x - 1; x++) {
-        for (uint64 y = 0; y < image.size.y - 1; y++) {
-            float top_left = min((get_alpha(image, x, y) * scale), 1.0);
-            float top_right = min((get_alpha(image, x + 1, y) * scale), 1.0);
-            float bottom_left = min((get_alpha(image, x, y + 1) * scale), 1.0);
-            float bottom_right = min((get_alpha(image, x + 1, y + 1) * scale), 1.0);
-
-            float texel_coverage = 0.0;
-            for (int sy = 0; sy < subsample_factor; sy++) {
-                float fy = ((float)sy + 0.5) / (float)subsample_factor;
-                for (int sx = 0; sx < subsample_factor; sx++) {
-                    float fx = ((float)sx + 0.5) / (float)subsample_factor;
-                    float alpha = top_left * (1.0 - fx) * (1.0 - fy)
-                        + top_right * fx * (1.0 - fy)
-                        + bottom_left * (1.0 - fx) * fy
-                        + bottom_right * fx * fy;
-
-                    if (alpha_cutoff) {
-                        if (alpha > *alpha_cutoff) {
-                            texel_coverage += 1.0;
-                        }
-                    }
-                    else {
-                        texel_coverage += alpha;
+                if (alpha_cutoff) {
+                    if (alpha > *alpha_cutoff) {
+                        coverage += 1.0f;
                     }
                 }
+                else {
+                    coverage += alpha;
+                }
             }
-            coverage += texel_coverage / (float)(subsample_factor * subsample_factor);
         }
+        return reduce_add(coverage) / (float)((image.size.x) * (image.size.y));
     }
+    else {
+        float coverage = 0.0f;
+        const uniform int subsample_factor = 4;
 
-    return reduce_add(coverage) / (float)((image.size.x - 1) * (image.size.y - 1));
+        for (uint64 x = 0; x < image.size.x - 1; x++) {
+            for (uint64 y = 0; y < image.size.y - 1; y++) {
+                float top_left = min((get_alpha(image, x, y) * scale), 1.0);
+                float top_right = min((get_alpha(image, x + 1, y) * scale), 1.0);
+                float bottom_left = min((get_alpha(image, x, y + 1) * scale), 1.0);
+                float bottom_right = min((get_alpha(image, x + 1, y + 1) * scale), 1.0);
+
+                float texel_coverage = 0.0;
+                for (int sy = 0; sy < subsample_factor; sy++) {
+                    float fy = ((float)sy + 0.5) / (float)subsample_factor;
+                    for (int sx = 0; sx < subsample_factor; sx++) {
+                        float fx = ((float)sx + 0.5) / (float)subsample_factor;
+                        float alpha = top_left * (1.0 - fx) * (1.0 - fy)
+                            + top_right * fx * (1.0 - fy)
+                            + bottom_left * (1.0 - fx) * fy
+                            + bottom_right * fx * fy;
+
+                        if (alpha_cutoff) {
+                            if (alpha > *alpha_cutoff) {
+                                texel_coverage += 1.0;
+                            }
+                        }
+                        else {
+                            texel_coverage += alpha;
+                        }
+                    }
+                }
+                coverage += texel_coverage / (float)(subsample_factor * subsample_factor);
+            }
+        }
+
+        return reduce_add(coverage) / (float)((image.size.x - 1) * (image.size.y - 1));
+    }
 }
 
 uniform float calculate_alpha_coverage(uniform Image image, uniform float* uniform alpha_cutoff) {
@@ -71,7 +88,7 @@ uniform float find_alpha_scale_for_coverage(uniform Image image, uniform float d
     // compared to mip 0
     // TO-DO: Figure out if this should be exposed
     uniform float alpha_scale_range_start = 0.0;
-    uniform float alpha_scale_range_end = 8.0;
+    uniform float alpha_scale_range_end = 32.0;
 
     uniform float alpha_scale = 1.0;
 
@@ -84,7 +101,7 @@ uniform float find_alpha_scale_for_coverage(uniform Image image, uniform float d
 
     // 10-step binary search for the alpha multiplier that best matches
     // the desired alpha coverage
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < 16; i++) {
         uniform float current_coverage = calculate_scaled_alpha_coverage(image, alpha_cutoff, alpha_scale);
         uniform float coverage_diff = current_coverage - desired_coverage;
 

--- a/src/ispc/kernels/rescale_alpha.ispc
+++ b/src/ispc/kernels/rescale_alpha.ispc
@@ -88,7 +88,7 @@ uniform float find_alpha_scale_for_coverage(uniform Image image, uniform float d
     // compared to mip 0
     // TO-DO: Figure out if this should be exposed
     uniform float alpha_scale_range_start = 0.0;
-    uniform float alpha_scale_range_end = 32.0;
+    uniform float alpha_scale_range_end = 8.0;
 
     uniform float alpha_scale = 1.0;
 
@@ -101,7 +101,7 @@ uniform float find_alpha_scale_for_coverage(uniform Image image, uniform float d
 
     // 10-step binary search for the alpha multiplier that best matches
     // the desired alpha coverage
-    for (int i = 0; i < 16; i++) {
+    for (int i = 0; i < 10; i++) {
         uniform float current_coverage = calculate_scaled_alpha_coverage(image, alpha_cutoff, alpha_scale);
         uniform float coverage_diff = current_coverage - desired_coverage;
 


### PR DESCRIPTION
The previous coverage returned for 1x1 images was incorrect and should have checked its alpha instead, but I noticed that this was wrong for any single column or row case (i.e. size 1 x n or n x 1), due to the use of subsampling. This would make the alpha coverage accumulation always result in zero and trigger a division by zero right after. 

This change makes it so that single row or column images simply don't use the subsampling pattern, as it's likely not sound to do the subsampling in only one dimension.