### PR TITLE
CI: Always install the Rust target for MacOS on x86_64

### DIFF
--- a/.github/workflows/generate-binaries.yaml
+++ b/.github/workflows/generate-binaries.yaml
@@ -62,7 +62,7 @@ jobs:
           echo "$PWD" >> $GITHUB_PATH
 
       - name: Install additional targets
-        run: rustup target add aarch64-apple-darwin aarch64-apple-ios
+        run: rustup target add x86_64-apple-darwin aarch64-apple-darwin aarch64-apple-ios
 
       - name: Build binaries
         run: |


### PR DESCRIPTION
According to [GitHub documentation] it is now possible to get a Mac M1 runner using the aarch64 architecture.  This means `x86_64` is no longer the only host architecture for which we expect the `x86_64-apple-darwin` target to always be natively installed.

Install it unconditionally next to the `aarch64` Mac/iOS triples and let `rustup` figure out and skip what's already installed.

[GitHub documentation]: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners
