### PR TITLE
🪥 #48 API cleanup

### DIFF
--- a/benches/basic.rs
+++ b/benches/basic.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use ispc_downsampler::{downsample, Format, Image};
+use ispc_downsampler::{downsample, AlbedoFormat, Image};
 use resize::{px::RGB, Type::Lanczos3};
 use stb_image::image::{load, LoadResult};
 use std::path::Path;
@@ -9,26 +9,18 @@ const DOWNSCALE: usize = 4;
 pub fn ispc_downsampler(c: &mut Criterion) {
     if let LoadResult::ImageU8(img) = load(Path::new("test_assets/square_test.png")) {
         let src_fmt = if img.data.len() / (img.width * img.height) == 4 {
-            Format::Rgba8Unorm
+            AlbedoFormat::Rgba8Unorm
         } else {
-            Format::Rgb8Unorm
+            AlbedoFormat::Rgb8Unorm
         };
 
-        let src_img = Image::new(&img.data, img.width as u32, img.height as u32);
+        let src_img = Image::new(&img.data, img.width as u32, img.height as u32, src_fmt);
 
         let target_width = (img.width / DOWNSCALE) as u32;
         let target_height = (img.height / DOWNSCALE) as u32;
 
         c.bench_function("Downsample `square_test.png` using ispc_downsampler", |b| {
-            b.iter(|| {
-                downsample(
-                    &src_img,
-                    target_width,
-                    target_height,
-                    src_fmt.pixel_size(),
-                    src_fmt,
-                )
-            })
+            b.iter(|| downsample(&src_img, target_width, target_height))
         });
     }
 }

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -1,5 +1,5 @@
 use image::{RgbImage, RgbaImage};
-use ispc_downsampler::{downsample_with_custom_scale, Format, Image};
+use ispc_downsampler::{downsample_with_custom_scale, AlbedoFormat, Image};
 use stb_image::image::{load, LoadResult};
 use std::path::Path;
 use std::time::Instant;
@@ -12,33 +12,27 @@ fn main() {
             assert!(!img.data.is_empty());
 
             let src_fmt = if img.data.len() / (img.width * img.height) == 4 {
-                Format::Rgba8Unorm
+                AlbedoFormat::Rgba8Unorm
             } else {
-                Format::Rgb8Unorm
+                AlbedoFormat::Rgb8Unorm
             };
 
             println!("Loaded image!");
 
-            let src_img = Image::new(&img.data, img.width as u32, img.height as u32);
+            let src_img = Image::new(&img.data, img.width as u32, img.height as u32, src_fmt);
 
             let target_width = (img.width / 2) as u32;
             let target_height = (img.height / 2) as u32;
 
             let now = Instant::now();
             println!("Downsampling started!");
-            let downsampled_pixels = downsample_with_custom_scale(
-                &src_img,
-                target_width,
-                target_height,
-                1.0,
-                src_fmt.pixel_size(),
-                src_fmt,
-            );
+            let downsampled_pixels =
+                downsample_with_custom_scale(&src_img, target_width, target_height, 1.0);
 
             println!("Finished downsampling in {:.2?}!", now.elapsed());
             std::fs::create_dir_all("example_outputs").unwrap();
             match src_fmt {
-                Format::Rgba8Unorm => {
+                AlbedoFormat::Rgba8Unorm => {
                     let save_image =
                         RgbaImage::from_vec(target_width, target_height, downsampled_pixels)
                             .unwrap();
@@ -46,7 +40,7 @@ fn main() {
                         .save("example_outputs/square_test_result.png")
                         .unwrap()
                 }
-                Format::Rgb8Unorm => {
+                AlbedoFormat::Rgb8Unorm => {
                     let save_image =
                         RgbImage::from_vec(target_width, target_height, downsampled_pixels)
                             .unwrap();


### PR DESCRIPTION
In #48 we added an alternative downsampling path specifically for normal maps which renormalizes them and allows for format that have the Z-component reconstructed from X and Y. Also, due to our app using 4-channel texture for the normal maps during asset building, we needed to introduce a pixel stride parameter so we can correctly sample the normal maps.

This lead to several API changes which, in hindsight, were not done the best, such as exposing a mandatory pixel stride parameter for the downsampling function and the format getting separated from the `Image` struct because of the existence of two different format enums.

This PR attempts to correct these issues by doing a few things:
- A new `trait ImagePixelFormat` is added which establishes an interface that both `NormalMapFormat` and `AlbedoFormat` (Previously named only `Format`) need to fulfil.
- `struct Image` now uses a generic `F: ImagePixelFormat` so that the struct can be reused for both regular images and for normal maps.
- The pixel stride parameter was moved into the `Image` struct. Using `Image::new()` will assume the stride is the same as the Format's pixel side, while a newly added `Image::new_with_pixel_stride()` allows a specific value to be given to the stride.
- The format and pixel stride parameters were removed from the downsampling function signatures, as they should now be accessed from the source `Image` instead. `downsample_normal_map` requires `Image` to use a `NormalMapFormat`, while `downsample` and `scale_alpha_to_original_coverage` require `AlbedoFormat` to be used instead.
