### PR TITLE
🧵 Benchmark against single threaded version of resize crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ ispc_rt = "2"
 image = "0.25.1"
 stb_image = "0.3.0"
 criterion = "0.5"
+
+# Make sure we do an apples to apples, single threaded, comparison in the benchmark
 resize = { version = "0.8", default-features = false, features = ["std"] }
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ ispc_rt = "2"
 image = "0.25.1"
 stb_image = "0.3.0"
 criterion = "0.5"
-resize = "0.8"
+resize = { version = "0.8", default-features = false, features = ["std"] }
 
 [[bench]]
 name = "basic"


### PR DESCRIPTION
Noticed this when inspecting performance. We're still slower then `resize` in our `downsample` but at least we should start on equal footing.