### PR TITLE
CI/generate-binaries: Drop `--release` flag from Apple build artifacts

### DIFF
--- a/.github/workflows/generate-binaries.yaml
+++ b/.github/workflows/generate-binaries.yaml
@@ -66,9 +66,9 @@ jobs:
 
       - name: Build binaries
         run: |
-          cargo build --features=ispc --release --target=x86_64-apple-darwin
-          cargo build --features=ispc --release --target=aarch64-apple-darwin
-          cargo build --features=ispc --release --target=aarch64-apple-ios
+          cargo build --features=ispc --target=x86_64-apple-darwin
+          cargo build --features=ispc --target=aarch64-apple-darwin
+          cargo build --features=ispc --target=aarch64-apple-ios
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Neither Linux nor Windows build these artifacts in `--release`, and `ispc-compile` doesn't parse `PROFILE` to pass this down into `ispc` either; the resulting native libraries should remain unchanged. This was probably an accidental copy-paste when I introduced it in https://github.com/Traverse-Research/ispc-downsampler/pull/5/commits/8bc24e8d7d88293dc83386c62578372fe6addd0f.
